### PR TITLE
add .github/releases.yml

### DIFF
--- a/.github/releases.yml
+++ b/.github/releases.yml
@@ -1,0 +1,24 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: Exciting New Features 🎉
+      labels:
+        - enhancement
+    - title: Bug fixes🧑‍🔧 🐞
+      labels:
+        - enhancement
+    - title: Doc improvements 📚
+      labels:
+        - doc
+        - documentation
+    - title: Other Changes
+      labels:
+        - "*"
+

--- a/.github/releases.yml
+++ b/.github/releases.yml
@@ -13,10 +13,10 @@ changelog:
         - enhancement
     - title: Bug fixes🧑‍🔧 🐞
       labels:
-        - enhancement
+        - bug 
     - title: Doc improvements 📚
       labels:
-        - doc
+        - docs
         - documentation
     - title: Other Changes
       labels:


### PR DESCRIPTION
Hello there, this should help creating nice release pages, like this one:

https://github.com/hashicorp/packer-plugin-googlecompute/releases/tag/v1.0.8

Docs are here: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes