### PR TITLE
remove unecessary check for symbolic link for volume mounted (WIP)

### DIFF
--- a/builder/osc/common/block_device.go
+++ b/builder/osc/common/block_device.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 	oscgo "github.com/outscale/osc-sdk-go/v2"
 )
@@ -69,7 +68,7 @@ func buildOscBlockDevicesImage(b []BlockDevice) []oscgo.BlockDeviceMappingImage 
 				bsu.SnapshotId = &blockDevice.SnapshotId
 			}
 
-			mapping.Bsu = &bsu
+			mapping.SetBsu(bsu)
 		}
 
 		blockDevices = append(blockDevices, mapping)
@@ -88,7 +87,7 @@ func buildOscBlockDevicesVmCreation(b []BlockDevice) []oscgo.BlockDeviceMappingV
 		}
 
 		if blockDevice.NoDevice {
-			mapping.NoDevice = aws.String("")
+			mapping.NoDevice = oscgo.PtrString("")
 			//blockDevices = mapping[0]
 		} else if blockDevice.VirtualName != "" {
 			if strings.HasPrefix(blockDevice.VirtualName, "ephemeral") {
@@ -117,7 +116,7 @@ func buildOscBlockDevicesVmCreation(b []BlockDevice) []oscgo.BlockDeviceMappingV
 				bsu.SnapshotId = &blockDevice.SnapshotId
 			}
 
-			mapping.Bsu = &bsu
+			mapping.SetBsu(bsu)
 		}
 
 		blockDevices = append(blockDevices, mapping)

--- a/example/osc-chroot.pkr.hcl
+++ b/example/osc-chroot.pkr.hcl
@@ -7,6 +7,7 @@ variable "osc_secret_key" {
     type    = string
     default = "${env("OSC_SECRET_KEY")}"
 }
+
 packer {
   required_plugins {
     outscale = {
@@ -23,12 +24,15 @@ source "outscale-chroot" "windows" {
   from_scratch = true
   pre_mount_commands = [
     "parted {{.Device}} mklabel msdos mkpart primary 1M 100% set 1 boot on print",
-    "mkfs.ext4 {{.Device}}1"
+    "fdisk  {{.Device}}",
+    "sleep 1",
+    "mkfs -t xfs -f {{.Device}}"
   ]
   root_volume_size = 15
-  root_device_name = "xvdf"
+  root_device_name =  "xvda"
   omi_block_device_mappings {
-      device_name = "xvdf"
+      delete_on_vm_deletion = false
+      device_name =  "xvda"
       volume_type = "gp2"
   }
 }


### PR DESCRIPTION
This PR is to fix the chroot builder example,  remove the check of the symbolic link of the volume created 
and to fix getters and setters for sdk go v2 for block_device
   