### PR TITLE
Update outscale-bsuvolume.mdx

### DIFF
--- a/docs/builders/outscale-bsuvolume.mdx
+++ b/docs/builders/outscale-bsuvolume.mdx
@@ -156,6 +156,10 @@ builder.
 
   Where Packer is configured for an outbound proxy but WinRM traffic should be direct, `ssh_interface` must be set to `private_dns` and `<region>.compute.internal` included in the `NO_PROXY` environment variable.
 
+- `ssh_username` (string) - The name of the user to SSH into on the provided instance.
+
+- `ssh_port` (string) - The port to use in order to establish the SSH connection. Useful in case you do not use default SSH port on your source OMI.
+
 - `subnet_id` (string) - If using Net, the ID of the subnet, such as `subnet-12345def`, where Packer will launch the VM. This field is required if you are using an non-default Net.
 
 - `temporary_key_pair_name` (string) - The name of the temporary key pair to generate. By default, Packer generates a name that looks like `packer_<UUID>`, where &lt;UUID&gt; is a 36 character unique identifier.


### PR DESCRIPTION
Added missing properties, useful in case of non-default use of values for SSH