### PR TITLE
fix warning duplicate cty tag

### DIFF
--- a/builder/osc/bsu/builder.hcl2spec.go
+++ b/builder/osc/bsu/builder.hcl2spec.go
@@ -26,7 +26,6 @@ type FlatConfig struct {
 	ProfileName                 *string                                `mapstructure:"profile" cty:"profile" hcl:"profile"`
 	RawRegion                   *string                                `mapstructure:"region" cty:"region" hcl:"region"`
 	SecretKey                   *string                                `mapstructure:"secret_key" cty:"secret_key" hcl:"secret_key"`
-	SkipValidation              *bool                                  `mapstructure:"skip_region_validation" cty:"skip_region_validation" hcl:"skip_region_validation"`
 	SkipMetadataApiCheck        *bool                                  `mapstructure:"skip_metadata_api_check" cty:"skip_metadata_api_check" hcl:"skip_metadata_api_check"`
 	Token                       *string                                `mapstructure:"token" cty:"token" hcl:"token"`
 	X509certPath                *string                                `mapstructure:"x509_cert_path" cty:"x509_cert_path" hcl:"x509_cert_path"`
@@ -37,6 +36,7 @@ type FlatConfig struct {
 	OMIGroups                   []string                               `mapstructure:"omi_groups" cty:"omi_groups" hcl:"omi_groups"`
 	OMIProductCodes             []string                               `mapstructure:"omi_product_codes" cty:"omi_product_codes" hcl:"omi_product_codes"`
 	OMIRegions                  []string                               `mapstructure:"omi_regions" cty:"omi_regions" hcl:"omi_regions"`
+	OMISkipRegionValidation     *bool                                  `mapstructure:"skip_region_validation" cty:"skip_region_validation" hcl:"skip_region_validation"`
 	OMITags                     common.TagMap                          `mapstructure:"tags" cty:"tags" hcl:"tags"`
 	OMIForceDeregister          *bool                                  `mapstructure:"force_deregister" cty:"force_deregister" hcl:"force_deregister"`
 	OMIForceDeleteSnapshot      *bool                                  `mapstructure:"force_delete_snapshot" cty:"force_delete_snapshot" hcl:"force_delete_snapshot"`
@@ -63,7 +63,6 @@ type FlatConfig struct {
 	SourceOmiFilter             *common.FlatOmiFilterOptions           `mapstructure:"source_omi_filter" cty:"source_omi_filter" hcl:"source_omi_filter"`
 	SubnetFilter                *common.FlatSubnetFilterOptions        `mapstructure:"subnet_filter" cty:"subnet_filter" hcl:"subnet_filter"`
 	SubnetId                    *string                                `mapstructure:"subnet_id" cty:"subnet_id" hcl:"subnet_id"`
-	TemporaryKeyPairName        *string                                `mapstructure:"temporary_key_pair_name" cty:"temporary_key_pair_name" hcl:"temporary_key_pair_name"`
 	TemporarySGSourceCidr       *string                                `mapstructure:"temporary_security_group_source_cidr" cty:"temporary_security_group_source_cidr" hcl:"temporary_security_group_source_cidr"`
 	UserData                    *string                                `mapstructure:"user_data" cty:"user_data" hcl:"user_data"`
 	UserDataFile                *string                                `mapstructure:"user_data_file" cty:"user_data_file" hcl:"user_data_file"`
@@ -77,6 +76,7 @@ type FlatConfig struct {
 	SSHUsername                 *string                                `mapstructure:"ssh_username" cty:"ssh_username" hcl:"ssh_username"`
 	SSHPassword                 *string                                `mapstructure:"ssh_password" cty:"ssh_password" hcl:"ssh_password"`
 	SSHKeyPairName              *string                                `mapstructure:"ssh_keypair_name" undocumented:"true" cty:"ssh_keypair_name" hcl:"ssh_keypair_name"`
+	SSHTemporaryKeyPairName     *string                                `mapstructure:"temporary_key_pair_name" undocumented:"true" cty:"temporary_key_pair_name" hcl:"temporary_key_pair_name"`
 	SSHTemporaryKeyPairType     *string                                `mapstructure:"temporary_key_pair_type" cty:"temporary_key_pair_type" hcl:"temporary_key_pair_type"`
 	SSHTemporaryKeyPairBits     *int                                   `mapstructure:"temporary_key_pair_bits" cty:"temporary_key_pair_bits" hcl:"temporary_key_pair_bits"`
 	SSHCiphers                  []string                               `mapstructure:"ssh_ciphers" cty:"ssh_ciphers" hcl:"ssh_ciphers"`
@@ -149,7 +149,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"profile":                              &hcldec.AttrSpec{Name: "profile", Type: cty.String, Required: false},
 		"region":                               &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
 		"secret_key":                           &hcldec.AttrSpec{Name: "secret_key", Type: cty.String, Required: false},
-		"skip_region_validation":               &hcldec.AttrSpec{Name: "skip_region_validation", Type: cty.Bool, Required: false},
 		"skip_metadata_api_check":              &hcldec.AttrSpec{Name: "skip_metadata_api_check", Type: cty.Bool, Required: false},
 		"token":                                &hcldec.AttrSpec{Name: "token", Type: cty.String, Required: false},
 		"x509_cert_path":                       &hcldec.AttrSpec{Name: "x509_cert_path", Type: cty.String, Required: false},
@@ -160,6 +159,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"omi_groups":                           &hcldec.AttrSpec{Name: "omi_groups", Type: cty.List(cty.String), Required: false},
 		"omi_product_codes":                    &hcldec.AttrSpec{Name: "omi_product_codes", Type: cty.List(cty.String), Required: false},
 		"omi_regions":                          &hcldec.AttrSpec{Name: "omi_regions", Type: cty.List(cty.String), Required: false},
+		"skip_region_validation":               &hcldec.AttrSpec{Name: "skip_region_validation", Type: cty.Bool, Required: false},
 		"tags":                                 &hcldec.AttrSpec{Name: "tags", Type: cty.Map(cty.String), Required: false},
 		"force_deregister":                     &hcldec.AttrSpec{Name: "force_deregister", Type: cty.Bool, Required: false},
 		"force_delete_snapshot":                &hcldec.AttrSpec{Name: "force_delete_snapshot", Type: cty.Bool, Required: false},
@@ -186,7 +186,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"source_omi_filter":                    &hcldec.BlockSpec{TypeName: "source_omi_filter", Nested: hcldec.ObjectSpec((*common.FlatOmiFilterOptions)(nil).HCL2Spec())},
 		"subnet_filter":                        &hcldec.BlockSpec{TypeName: "subnet_filter", Nested: hcldec.ObjectSpec((*common.FlatSubnetFilterOptions)(nil).HCL2Spec())},
 		"subnet_id":                            &hcldec.AttrSpec{Name: "subnet_id", Type: cty.String, Required: false},
-		"temporary_key_pair_name":              &hcldec.AttrSpec{Name: "temporary_key_pair_name", Type: cty.String, Required: false},
 		"temporary_security_group_source_cidr": &hcldec.AttrSpec{Name: "temporary_security_group_source_cidr", Type: cty.String, Required: false},
 		"user_data":                            &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},
 		"user_data_file":                       &hcldec.AttrSpec{Name: "user_data_file", Type: cty.String, Required: false},
@@ -200,6 +199,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ssh_username":                         &hcldec.AttrSpec{Name: "ssh_username", Type: cty.String, Required: false},
 		"ssh_password":                         &hcldec.AttrSpec{Name: "ssh_password", Type: cty.String, Required: false},
 		"ssh_keypair_name":                     &hcldec.AttrSpec{Name: "ssh_keypair_name", Type: cty.String, Required: false},
+		"temporary_key_pair_name":              &hcldec.AttrSpec{Name: "temporary_key_pair_name", Type: cty.String, Required: false},
 		"temporary_key_pair_type":              &hcldec.AttrSpec{Name: "temporary_key_pair_type", Type: cty.String, Required: false},
 		"temporary_key_pair_bits":              &hcldec.AttrSpec{Name: "temporary_key_pair_bits", Type: cty.Number, Required: false},
 		"ssh_ciphers":                          &hcldec.AttrSpec{Name: "ssh_ciphers", Type: cty.List(cty.String), Required: false},

--- a/builder/osc/bsusurrogate/builder.hcl2spec.go
+++ b/builder/osc/bsusurrogate/builder.hcl2spec.go
@@ -26,7 +26,6 @@ type FlatConfig struct {
 	ProfileName                 *string                                `mapstructure:"profile" cty:"profile" hcl:"profile"`
 	RawRegion                   *string                                `mapstructure:"region" cty:"region" hcl:"region"`
 	SecretKey                   *string                                `mapstructure:"secret_key" cty:"secret_key" hcl:"secret_key"`
-	SkipValidation              *bool                                  `mapstructure:"skip_region_validation" cty:"skip_region_validation" hcl:"skip_region_validation"`
 	SkipMetadataApiCheck        *bool                                  `mapstructure:"skip_metadata_api_check" cty:"skip_metadata_api_check" hcl:"skip_metadata_api_check"`
 	Token                       *string                                `mapstructure:"token" cty:"token" hcl:"token"`
 	X509certPath                *string                                `mapstructure:"x509_cert_path" cty:"x509_cert_path" hcl:"x509_cert_path"`
@@ -48,7 +47,6 @@ type FlatConfig struct {
 	SourceOmiFilter             *common.FlatOmiFilterOptions           `mapstructure:"source_omi_filter" cty:"source_omi_filter" hcl:"source_omi_filter"`
 	SubnetFilter                *common.FlatSubnetFilterOptions        `mapstructure:"subnet_filter" cty:"subnet_filter" hcl:"subnet_filter"`
 	SubnetId                    *string                                `mapstructure:"subnet_id" cty:"subnet_id" hcl:"subnet_id"`
-	TemporaryKeyPairName        *string                                `mapstructure:"temporary_key_pair_name" cty:"temporary_key_pair_name" hcl:"temporary_key_pair_name"`
 	TemporarySGSourceCidr       *string                                `mapstructure:"temporary_security_group_source_cidr" cty:"temporary_security_group_source_cidr" hcl:"temporary_security_group_source_cidr"`
 	UserData                    *string                                `mapstructure:"user_data" cty:"user_data" hcl:"user_data"`
 	UserDataFile                *string                                `mapstructure:"user_data_file" cty:"user_data_file" hcl:"user_data_file"`
@@ -62,6 +60,7 @@ type FlatConfig struct {
 	SSHUsername                 *string                                `mapstructure:"ssh_username" cty:"ssh_username" hcl:"ssh_username"`
 	SSHPassword                 *string                                `mapstructure:"ssh_password" cty:"ssh_password" hcl:"ssh_password"`
 	SSHKeyPairName              *string                                `mapstructure:"ssh_keypair_name" undocumented:"true" cty:"ssh_keypair_name" hcl:"ssh_keypair_name"`
+	SSHTemporaryKeyPairName     *string                                `mapstructure:"temporary_key_pair_name" undocumented:"true" cty:"temporary_key_pair_name" hcl:"temporary_key_pair_name"`
 	SSHTemporaryKeyPairType     *string                                `mapstructure:"temporary_key_pair_type" cty:"temporary_key_pair_type" hcl:"temporary_key_pair_type"`
 	SSHTemporaryKeyPairBits     *int                                   `mapstructure:"temporary_key_pair_bits" cty:"temporary_key_pair_bits" hcl:"temporary_key_pair_bits"`
 	SSHCiphers                  []string                               `mapstructure:"ssh_ciphers" cty:"ssh_ciphers" hcl:"ssh_ciphers"`
@@ -112,6 +111,7 @@ type FlatConfig struct {
 	OMIGroups                   []string                               `mapstructure:"omi_groups" cty:"omi_groups" hcl:"omi_groups"`
 	OMIProductCodes             []string                               `mapstructure:"omi_product_codes" cty:"omi_product_codes" hcl:"omi_product_codes"`
 	OMIRegions                  []string                               `mapstructure:"omi_regions" cty:"omi_regions" hcl:"omi_regions"`
+	OMISkipRegionValidation     *bool                                  `mapstructure:"skip_region_validation" cty:"skip_region_validation" hcl:"skip_region_validation"`
 	OMITags                     common.TagMap                          `mapstructure:"tags" cty:"tags" hcl:"tags"`
 	OMIForceDeregister          *bool                                  `mapstructure:"force_deregister" cty:"force_deregister" hcl:"force_deregister"`
 	OMIForceDeleteSnapshot      *bool                                  `mapstructure:"force_delete_snapshot" cty:"force_delete_snapshot" hcl:"force_delete_snapshot"`
@@ -150,7 +150,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"profile":                              &hcldec.AttrSpec{Name: "profile", Type: cty.String, Required: false},
 		"region":                               &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
 		"secret_key":                           &hcldec.AttrSpec{Name: "secret_key", Type: cty.String, Required: false},
-		"skip_region_validation":               &hcldec.AttrSpec{Name: "skip_region_validation", Type: cty.Bool, Required: false},
 		"skip_metadata_api_check":              &hcldec.AttrSpec{Name: "skip_metadata_api_check", Type: cty.Bool, Required: false},
 		"token":                                &hcldec.AttrSpec{Name: "token", Type: cty.String, Required: false},
 		"x509_cert_path":                       &hcldec.AttrSpec{Name: "x509_cert_path", Type: cty.String, Required: false},
@@ -172,7 +171,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"source_omi_filter":                    &hcldec.BlockSpec{TypeName: "source_omi_filter", Nested: hcldec.ObjectSpec((*common.FlatOmiFilterOptions)(nil).HCL2Spec())},
 		"subnet_filter":                        &hcldec.BlockSpec{TypeName: "subnet_filter", Nested: hcldec.ObjectSpec((*common.FlatSubnetFilterOptions)(nil).HCL2Spec())},
 		"subnet_id":                            &hcldec.AttrSpec{Name: "subnet_id", Type: cty.String, Required: false},
-		"temporary_key_pair_name":              &hcldec.AttrSpec{Name: "temporary_key_pair_name", Type: cty.String, Required: false},
 		"temporary_security_group_source_cidr": &hcldec.AttrSpec{Name: "temporary_security_group_source_cidr", Type: cty.String, Required: false},
 		"user_data":                            &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},
 		"user_data_file":                       &hcldec.AttrSpec{Name: "user_data_file", Type: cty.String, Required: false},
@@ -186,6 +184,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ssh_username":                         &hcldec.AttrSpec{Name: "ssh_username", Type: cty.String, Required: false},
 		"ssh_password":                         &hcldec.AttrSpec{Name: "ssh_password", Type: cty.String, Required: false},
 		"ssh_keypair_name":                     &hcldec.AttrSpec{Name: "ssh_keypair_name", Type: cty.String, Required: false},
+		"temporary_key_pair_name":              &hcldec.AttrSpec{Name: "temporary_key_pair_name", Type: cty.String, Required: false},
 		"temporary_key_pair_type":              &hcldec.AttrSpec{Name: "temporary_key_pair_type", Type: cty.String, Required: false},
 		"temporary_key_pair_bits":              &hcldec.AttrSpec{Name: "temporary_key_pair_bits", Type: cty.Number, Required: false},
 		"ssh_ciphers":                          &hcldec.AttrSpec{Name: "ssh_ciphers", Type: cty.List(cty.String), Required: false},
@@ -236,6 +235,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"omi_groups":                           &hcldec.AttrSpec{Name: "omi_groups", Type: cty.List(cty.String), Required: false},
 		"omi_product_codes":                    &hcldec.AttrSpec{Name: "omi_product_codes", Type: cty.List(cty.String), Required: false},
 		"omi_regions":                          &hcldec.AttrSpec{Name: "omi_regions", Type: cty.List(cty.String), Required: false},
+		"skip_region_validation":               &hcldec.AttrSpec{Name: "skip_region_validation", Type: cty.Bool, Required: false},
 		"tags":                                 &hcldec.AttrSpec{Name: "tags", Type: cty.Map(cty.String), Required: false},
 		"force_deregister":                     &hcldec.AttrSpec{Name: "force_deregister", Type: cty.Bool, Required: false},
 		"force_delete_snapshot":                &hcldec.AttrSpec{Name: "force_delete_snapshot", Type: cty.Bool, Required: false},

--- a/builder/osc/bsuvolume/builder.hcl2spec.go
+++ b/builder/osc/bsuvolume/builder.hcl2spec.go
@@ -65,7 +65,6 @@ type FlatConfig struct {
 	ProfileName                 *string                                `mapstructure:"profile" cty:"profile" hcl:"profile"`
 	RawRegion                   *string                                `mapstructure:"region" cty:"region" hcl:"region"`
 	SecretKey                   *string                                `mapstructure:"secret_key" cty:"secret_key" hcl:"secret_key"`
-	SkipValidation              *bool                                  `mapstructure:"skip_region_validation" cty:"skip_region_validation" hcl:"skip_region_validation"`
 	SkipMetadataApiCheck        *bool                                  `mapstructure:"skip_metadata_api_check" cty:"skip_metadata_api_check" hcl:"skip_metadata_api_check"`
 	Token                       *string                                `mapstructure:"token" cty:"token" hcl:"token"`
 	X509certPath                *string                                `mapstructure:"x509_cert_path" cty:"x509_cert_path" hcl:"x509_cert_path"`
@@ -87,7 +86,6 @@ type FlatConfig struct {
 	SourceOmiFilter             *common.FlatOmiFilterOptions           `mapstructure:"source_omi_filter" cty:"source_omi_filter" hcl:"source_omi_filter"`
 	SubnetFilter                *common.FlatSubnetFilterOptions        `mapstructure:"subnet_filter" cty:"subnet_filter" hcl:"subnet_filter"`
 	SubnetId                    *string                                `mapstructure:"subnet_id" cty:"subnet_id" hcl:"subnet_id"`
-	TemporaryKeyPairName        *string                                `mapstructure:"temporary_key_pair_name" cty:"temporary_key_pair_name" hcl:"temporary_key_pair_name"`
 	TemporarySGSourceCidr       *string                                `mapstructure:"temporary_security_group_source_cidr" cty:"temporary_security_group_source_cidr" hcl:"temporary_security_group_source_cidr"`
 	UserData                    *string                                `mapstructure:"user_data" cty:"user_data" hcl:"user_data"`
 	UserDataFile                *string                                `mapstructure:"user_data_file" cty:"user_data_file" hcl:"user_data_file"`
@@ -101,6 +99,7 @@ type FlatConfig struct {
 	SSHUsername                 *string                                `mapstructure:"ssh_username" cty:"ssh_username" hcl:"ssh_username"`
 	SSHPassword                 *string                                `mapstructure:"ssh_password" cty:"ssh_password" hcl:"ssh_password"`
 	SSHKeyPairName              *string                                `mapstructure:"ssh_keypair_name" undocumented:"true" cty:"ssh_keypair_name" hcl:"ssh_keypair_name"`
+	SSHTemporaryKeyPairName     *string                                `mapstructure:"temporary_key_pair_name" undocumented:"true" cty:"temporary_key_pair_name" hcl:"temporary_key_pair_name"`
 	SSHTemporaryKeyPairType     *string                                `mapstructure:"temporary_key_pair_type" cty:"temporary_key_pair_type" hcl:"temporary_key_pair_type"`
 	SSHTemporaryKeyPairBits     *int                                   `mapstructure:"temporary_key_pair_bits" cty:"temporary_key_pair_bits" hcl:"temporary_key_pair_bits"`
 	SSHCiphers                  []string                               `mapstructure:"ssh_ciphers" cty:"ssh_ciphers" hcl:"ssh_ciphers"`
@@ -173,7 +172,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"profile":                              &hcldec.AttrSpec{Name: "profile", Type: cty.String, Required: false},
 		"region":                               &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
 		"secret_key":                           &hcldec.AttrSpec{Name: "secret_key", Type: cty.String, Required: false},
-		"skip_region_validation":               &hcldec.AttrSpec{Name: "skip_region_validation", Type: cty.Bool, Required: false},
 		"skip_metadata_api_check":              &hcldec.AttrSpec{Name: "skip_metadata_api_check", Type: cty.Bool, Required: false},
 		"token":                                &hcldec.AttrSpec{Name: "token", Type: cty.String, Required: false},
 		"x509_cert_path":                       &hcldec.AttrSpec{Name: "x509_cert_path", Type: cty.String, Required: false},
@@ -195,7 +193,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"source_omi_filter":                    &hcldec.BlockSpec{TypeName: "source_omi_filter", Nested: hcldec.ObjectSpec((*common.FlatOmiFilterOptions)(nil).HCL2Spec())},
 		"subnet_filter":                        &hcldec.BlockSpec{TypeName: "subnet_filter", Nested: hcldec.ObjectSpec((*common.FlatSubnetFilterOptions)(nil).HCL2Spec())},
 		"subnet_id":                            &hcldec.AttrSpec{Name: "subnet_id", Type: cty.String, Required: false},
-		"temporary_key_pair_name":              &hcldec.AttrSpec{Name: "temporary_key_pair_name", Type: cty.String, Required: false},
 		"temporary_security_group_source_cidr": &hcldec.AttrSpec{Name: "temporary_security_group_source_cidr", Type: cty.String, Required: false},
 		"user_data":                            &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},
 		"user_data_file":                       &hcldec.AttrSpec{Name: "user_data_file", Type: cty.String, Required: false},
@@ -209,6 +206,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ssh_username":                         &hcldec.AttrSpec{Name: "ssh_username", Type: cty.String, Required: false},
 		"ssh_password":                         &hcldec.AttrSpec{Name: "ssh_password", Type: cty.String, Required: false},
 		"ssh_keypair_name":                     &hcldec.AttrSpec{Name: "ssh_keypair_name", Type: cty.String, Required: false},
+		"temporary_key_pair_name":              &hcldec.AttrSpec{Name: "temporary_key_pair_name", Type: cty.String, Required: false},
 		"temporary_key_pair_type":              &hcldec.AttrSpec{Name: "temporary_key_pair_type", Type: cty.String, Required: false},
 		"temporary_key_pair_bits":              &hcldec.AttrSpec{Name: "temporary_key_pair_bits", Type: cty.Number, Required: false},
 		"ssh_ciphers":                          &hcldec.AttrSpec{Name: "ssh_ciphers", Type: cty.List(cty.String), Required: false},

--- a/builder/osc/bsuvolume/builder_test.go
+++ b/builder/osc/bsuvolume/builder_test.go
@@ -61,7 +61,6 @@ func TestBuilderPrepare_InvalidShutdownBehavior(t *testing.T) {
 
 	// Test good
 	config["shutdown_behavior"] = "terminate"
-	config["skip_region_validation"] = true
 	_, warnings, err := b.Prepare(config)
 	if len(warnings) > 0 {
 		t.Fatalf("bad: %#v", warnings)

--- a/builder/osc/common/access_config.go
+++ b/builder/osc/common/access_config.go
@@ -23,7 +23,6 @@ type AccessConfig struct {
 	ProfileName           string `mapstructure:"profile"`
 	RawRegion             string `mapstructure:"region"`
 	SecretKey             string `mapstructure:"secret_key"`
-	SkipValidation        bool   `mapstructure:"skip_region_validation"`
 	SkipMetadataApiCheck  bool   `mapstructure:"skip_metadata_api_check"`
 	Token                 string `mapstructure:"token"`
 	X509certPath          string `mapstructure:"x509_cert_path"`

--- a/builder/osc/common/run_config.go
+++ b/builder/osc/common/run_config.go
@@ -76,7 +76,6 @@ type RunConfig struct {
 	SourceOmiFilter             OmiFilterOptions           `mapstructure:"source_omi_filter"`
 	SubnetFilter                SubnetFilterOptions        `mapstructure:"subnet_filter"`
 	SubnetId                    string                     `mapstructure:"subnet_id"`
-	TemporaryKeyPairName        string                     `mapstructure:"temporary_key_pair_name"`
 	TemporarySGSourceCidr       string                     `mapstructure:"temporary_security_group_source_cidr"`
 	UserData                    string                     `mapstructure:"user_data"`
 	UserDataFile                string                     `mapstructure:"user_data_file"`

--- a/datasource/omi/data.hcl2spec.go
+++ b/datasource/omi/data.hcl2spec.go
@@ -26,7 +26,6 @@ type FlatConfig struct {
 	ProfileName           *string                `mapstructure:"profile" cty:"profile" hcl:"profile"`
 	RawRegion             *string                `mapstructure:"region" cty:"region" hcl:"region"`
 	SecretKey             *string                `mapstructure:"secret_key" cty:"secret_key" hcl:"secret_key"`
-	SkipValidation        *bool                  `mapstructure:"skip_region_validation" cty:"skip_region_validation" hcl:"skip_region_validation"`
 	SkipMetadataApiCheck  *bool                  `mapstructure:"skip_metadata_api_check" cty:"skip_metadata_api_check" hcl:"skip_metadata_api_check"`
 	Token                 *string                `mapstructure:"token" cty:"token" hcl:"token"`
 	X509certPath          *string                `mapstructure:"x509_cert_path" cty:"x509_cert_path" hcl:"x509_cert_path"`
@@ -64,7 +63,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"profile":                    &hcldec.AttrSpec{Name: "profile", Type: cty.String, Required: false},
 		"region":                     &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
 		"secret_key":                 &hcldec.AttrSpec{Name: "secret_key", Type: cty.String, Required: false},
-		"skip_region_validation":     &hcldec.AttrSpec{Name: "skip_region_validation", Type: cty.Bool, Required: false},
 		"skip_metadata_api_check":    &hcldec.AttrSpec{Name: "skip_metadata_api_check", Type: cty.Bool, Required: false},
 		"token":                      &hcldec.AttrSpec{Name: "token", Type: cty.String, Required: false},
 		"x509_cert_path":             &hcldec.AttrSpec{Name: "x509_cert_path", Type: cty.String, Required: false},


### PR DESCRIPTION
This PR is :
- To remove duplicate cty tag 
- Delete "skipe-region-validation" from  bsuvolume builder test because according to the documentation it's not handled for this builder 
(See https://developer.hashicorp.com/packer/plugins/builders/outscale/outscale-bsuvolume) 