### PR TITLE
feat(ebs): Feature to create vm without snapshot

### DIFF
--- a/builder/bsu/builder.go
+++ b/builder/bsu/builder.go
@@ -32,7 +32,7 @@ type Config struct {
 	osccommon.BlockDevices `mapstructure:",squash"`
 	osccommon.RunConfig    `mapstructure:",squash"`
 	VolumeRunTags          osccommon.TagMap `mapstructure:"run_volume_tags"`
-	SkipSnapshot           bool             `mapstructure:"skip_snapshot"`
+	SkipCreateOmi          bool             `mapstructure:"skip_create_omi"`
 
 	ctx interpolate.Context
 }
@@ -184,7 +184,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		},
 	}
 
-	if !b.config.SkipSnapshot {
+	if !b.config.SkipCreateOmi {
 		steps = append(steps,
 			&stepCreateOMI{
 				RawRegion:    b.config.RawRegion,

--- a/builder/bsu/builder.hcl2spec.go
+++ b/builder/bsu/builder.hcl2spec.go
@@ -120,7 +120,7 @@ type FlatConfig struct {
 	WinRMUseNTLM                *bool                                  `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
 	SSHInterface                *string                                `mapstructure:"ssh_interface" cty:"ssh_interface" hcl:"ssh_interface"`
 	VolumeRunTags               common.TagMap                          `mapstructure:"run_volume_tags" cty:"run_volume_tags" hcl:"run_volume_tags"`
-	SkipSnapshot				*bool								   `mapstructure:"skip_snapshot" cty:"skip_snapshot" hcl:"skip_snapshot"`
+	SkipCreateOmi               *bool                                  `mapstructure:"skip_create_omi" cty:"skip_create_omi" hcl:"skip_create_omi"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -244,7 +244,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_use_ntlm":                       &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
 		"ssh_interface":                        &hcldec.AttrSpec{Name: "ssh_interface", Type: cty.String, Required: false},
 		"run_volume_tags":                      &hcldec.AttrSpec{Name: "run_volume_tags", Type: cty.Map(cty.String), Required: false},
-		"skip_snapshot": &hcldec.AttrSpec{			Name:     "skip_snapshot",			Type:     cty.Bool,			Required: false		},
+		"skip_create_omi":                      &hcldec.AttrSpec{Name: "skip_create_omi", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/builder/bsu/builder.hcl2spec.go
+++ b/builder/bsu/builder.hcl2spec.go
@@ -120,6 +120,7 @@ type FlatConfig struct {
 	WinRMUseNTLM                *bool                                  `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
 	SSHInterface                *string                                `mapstructure:"ssh_interface" cty:"ssh_interface" hcl:"ssh_interface"`
 	VolumeRunTags               common.TagMap                          `mapstructure:"run_volume_tags" cty:"run_volume_tags" hcl:"run_volume_tags"`
+	SkipSnapshot				*bool								   `mapstructure:"skip_snapshot" cty:"skip_snapshot" hcl:"skip_snapshot"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -243,6 +244,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_use_ntlm":                       &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
 		"ssh_interface":                        &hcldec.AttrSpec{Name: "ssh_interface", Type: cty.String, Required: false},
 		"run_volume_tags":                      &hcldec.AttrSpec{Name: "run_volume_tags", Type: cty.Map(cty.String), Required: false},
+		"skip_snapshot": &hcldec.AttrSpec{			Name:     "skip_snapshot",			Type:     cty.Bool,			Required: false		},
 	}
 	return s
 }

--- a/docs/builders/bsu.mdx
+++ b/docs/builders/bsu.mdx
@@ -162,6 +162,9 @@ builder.
 - `skip_region_validation` (boolean) - Set to true if you want to skip
   validation of the region configuration option. Default `false`.
 
+- `skip_snapshot` (boolean) - Set to true if you want to skip snapshot creation.
+  No image will be created if set to true. Default `false`.
+
 - `snapshot_groups` (array of strings) - A list of groups that have access to
   create volumes from the snapshot(s). By default no groups have permission
   to create volumes from the snapshot(s). `all` will make the snapshot

--- a/docs/builders/bsu.mdx
+++ b/docs/builders/bsu.mdx
@@ -159,11 +159,11 @@ builder.
   shutdown in case Packer exits ungracefully. Possible values are "stop" and
   "terminate", default is `stop`.
 
+- `skip_create_omi` (boolean) - Set to true if you want to skip snapshot creation.
+  No image will be created if set to true. Default `false`.
+
 - `skip_region_validation` (boolean) - Set to true if you want to skip
   validation of the region configuration option. Default `false`.
-
-- `skip_snapshot` (boolean) - Set to true if you want to skip snapshot creation.
-  No image will be created if set to true. Default `false`.
 
 - `snapshot_groups` (array of strings) - A list of groups that have access to
   create volumes from the snapshot(s). By default no groups have permission


### PR DESCRIPTION
Added a new flag on builder bsu to skip snapshot creation.
The goal to this feature is to be able to run provisioner(s) on ephemeral vm and destroy it without taking snapshot to run tests.
Flag name is `skip_snapshot` type boolean disabled by default.

The objective of this PR is to get a similar behavior of flag `skip_create_ami` on aws ebs builder.