### PR TITLE
♻️ refactor: configuration loading order

### DIFF
--- a/.web-docs/README.md
+++ b/.web-docs/README.md
@@ -80,17 +80,28 @@ These look like:
 
 #### Environment variables
 
-You can provide your credentials via the `OUTSCALE_ACCESSKEYID` and
-`OUTSCALE_SECRETKEYID`, environment variables, representing your Outscale Access
-Key and Outscale Secret Key, respectively. The `OUTSCALE_REGION` and
-`OUTSCALE_OAPI_URL` environment variables are also used, if applicable:
+You can provide your credentials via the following environment variables:
+
+- `OSC_ACCESS_KEY`
+- `OSC_SECRET_KEY`
+- `OSC_REGION`
+- `OSC_ENDPOINT_API`
 
 Usage:
 
-    $ export OUTSCALE_ACCESSKEYID="XXX_ACCESS_KEY_XXX"
-    $ export OUTSCALE_SECRETKEYID="XXX_SECRET_KEY_XXX"
-    $ export OUTSCALE_REGION="eu-west-2"
+    $ export OSC_ACCESS_KEY="XXX_ACCESS_KEY_XXX"
+    $ export OSC_SECRET_KEY="XXX_SECRET_KEY_XXX"
+    $ export OSC_REGION="eu-west-2"
     $ packer build template.pkr.hcl
+
+Legacy `OUTSCALE_*` variables are still supported for compatibility, but they are deprecated and will be removed in the next major version.
+
+Deprecated variables:
+
+- `OUTSCALE_ACCESSKEYID` -> `OSC_ACCESS_KEY`
+- `OUTSCALE_SECRETKEYID` -> `OSC_SECRET_KEY`
+- `OUTSCALE_REGION` -> `OSC_REGION`
+- `OUTSCALE_OAPI_URL` -> `OSC_ENDPOINT_API`
 
 #### x509 Certificate Authentication
 
@@ -102,9 +113,14 @@ You can set this certificates either by environment variables or by the static c
 ##### Environment variables
 
 ```bash
-export OUTSCALE_X509CERT="the/path/to/your/x509cert"
-export OUTSCALE_X509KEY="the/path/to/your/x509key"
+export OSC_X509_CLIENT_CERT="the/path/to/your/x509cert"
+export OSC_X509_CLIENT_KEY="the/path/to/your/x509key"
 ```
+
+Legacy x509 environment variables are also deprecated:
+
+- `OUTSCALE_X509CERT` -> `OSC_X509_CLIENT_CERT`
+- `OUTSCALE_X509KEY` -> `OSC_X509_CLIENT_KEY`
 
 ##### Static Credentials
 

--- a/builder/common/access_config.go
+++ b/builder/common/access_config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 	"github.com/outscale/osc-sdk-go/v3/pkg/options"
@@ -34,37 +35,74 @@ func (c *AccessConfig) GetRegion() string {
 	return c.RawRegion
 }
 
-func (c *AccessConfig) NewOSCClient() (*OscClient, error) {
-	profile, err := profile.NewFrom("", "")
-	if err != nil {
-		return nil, fmt.Errorf("new client: %w", err)
+func fromDeprecatedEnv() profile.Option {
+	return func(p *profile.Profile) error {
+		logDeprecation := func(deprecatedVar, replacementVar string) {
+			log.Printf("%s environment variable is deprecated and support will be dropped in the next major version, use the %s environment variable instead", deprecatedVar, replacementVar)
+		}
+
+		if ak, ok := os.LookupEnv("OUTSCALE_ACCESSKEYID"); ok {
+			p.AccessKey = ak
+			logDeprecation("OUTSCALE_ACCESSKEYID", "OSC_ACCESS_KEY")
+		}
+		if sk, ok := os.LookupEnv("OUTSCALE_SECRETKEYID"); ok {
+			p.SecretKey = sk
+			logDeprecation("OUTSCALE_SECRETKEYID", "OSC_SECRET_KEY")
+		}
+		if cert, ok := os.LookupEnv("OUTSCALE_X509CERT"); ok {
+			p.X509ClientCert = cert
+			logDeprecation("OUTSCALE_X509CERT", "OSC_X509_CLIENT_CERT")
+		}
+		if key, ok := os.LookupEnv("OUTSCALE_X509KEY"); ok {
+			p.X509ClientKey = key
+			logDeprecation("OUTSCALE_X509KEY", "OSC_X509_CLIENT_KEY")
+		}
+		if region, ok := os.LookupEnv("OUTSCALE_REGION"); ok {
+			p.Region = region
+			logDeprecation("OUTSCALE_REGION", "OSC_REGION")
+		}
+		if endpoint, ok := os.LookupEnv("OUTSCALE_OAPI_URL"); ok {
+			p.Endpoints.API = endpoint
+			logDeprecation("OUTSCALE_OAPI_URL", "OSC_ENDPOINT_API")
+		}
+
+		return nil
 	}
+}
 
-	profile.Protocol = "https"
-	profile.TlsSkipVerify = c.InsecureSkipTLSVerify
-
-	if c.RawRegion != "" {
+func fromConfig(c *AccessConfig) profile.Option {
+	return func(profile *profile.Profile) error {
+		profile.Protocol = "https"
+		profile.TlsSkipVerify = c.InsecureSkipTLSVerify
 		profile.Region = c.RawRegion
-	}
-	if c.AccessKey != "" {
 		profile.AccessKey = c.AccessKey
-	}
-	if c.SecretKey != "" {
 		profile.SecretKey = c.SecretKey
-	}
-	if c.X509certPath != "" {
 		profile.X509ClientCert = c.X509certPath
-	}
-	if c.X509keyPath != "" {
 		profile.X509ClientKey = c.X509keyPath
-	}
-	if c.CustomEndpointOAPI != "" {
 		profile.Endpoints.API = c.CustomEndpointOAPI
+
+		return nil
+	}
+}
+
+func (c *AccessConfig) NewProfile() (*profile.Profile, error) {
+	opts := []profile.Option{fromConfig(c), profile.MergeWith(profile.FromEnv()), profile.MergeWith(fromDeprecatedEnv())}
+	if c.ProfileName != "" {
+		opts = []profile.Option{fromConfig(c), profile.MergeWith(profile.FromFile(c.ProfileName, "")), profile.MergeWith(profile.FromEnv()), profile.MergeWith(fromDeprecatedEnv())}
+	}
+
+	return profile.New(opts...)
+}
+
+func (c *AccessConfig) NewOSCClient() (*OscClient, error) {
+	profile, err := c.NewProfile()
+	if err != nil {
+		return nil, fmt.Errorf("new profile: %w", err)
 	}
 
 	client, err := oscgo.NewClient(profile, options.WithLogging(newLogger()))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("new client: %w", err)
 	}
 
 	return &OscClient{

--- a/builder/common/access_config_test.go
+++ b/builder/common/access_config_test.go
@@ -28,10 +28,10 @@ func TestAccessconfigConfigPriority(t *testing.T) {
 		t.Fatalf("NewProfile: %v", err)
 	}
 	if p.AccessKey != "config-ak" {
-		t.Fatalf("expected config access key, got %q", p.AccessKey)
+		t.Fatalf("expected config access key")
 	}
 	if p.SecretKey != "config-sk" {
-		t.Fatalf("expected config secret key, got %q", p.SecretKey)
+		t.Fatalf("expected config secret key")
 	}
 	if p.Region != "config-region" {
 		t.Fatalf("expected config region, got %q", p.Region)
@@ -72,10 +72,10 @@ func TestAccessconfigProfilePriority(t *testing.T) {
 		t.Fatalf("NewProfile: %v", err)
 	}
 	if p.AccessKey != "file-ak" {
-		t.Fatalf("expected file access key, got %q", p.AccessKey)
+		t.Fatalf("expected file access key")
 	}
 	if p.SecretKey != "file-sk" {
-		t.Fatalf("expected file secret key, got %q", p.SecretKey)
+		t.Fatalf("expected file secret key")
 	}
 	if p.Region != "env-region" {
 		t.Fatalf("expected env region, got %q", p.Region)
@@ -97,10 +97,10 @@ func TestAccessconfigEnvPriority(t *testing.T) {
 		t.Fatalf("NewProfile: %v", err)
 	}
 	if p.AccessKey != "env-ak" {
-		t.Fatalf("expected env access key, got %q", p.AccessKey)
+		t.Fatalf("expected env access key")
 	}
 	if p.SecretKey != "env-sk" {
-		t.Fatalf("expected env secret key, got %q", p.SecretKey)
+		t.Fatalf("expected env secret key")
 	}
 	if p.Region != "env-region" {
 		t.Fatalf("expected env region, got %q", p.Region)
@@ -113,10 +113,22 @@ func TestAccessconfigDeprecatedEnv(t *testing.T) {
 	t.Setenv("OSC_SECRET_KEY", "")
 	t.Setenv("OSC_REGION", "")
 	t.Setenv("OSC_PROFILE", "")
-	os.Unsetenv("OSC_ACCESS_KEY")
-	os.Unsetenv("OSC_SECRET_KEY")
-	os.Unsetenv("OSC_REGION")
-	os.Unsetenv("OSC_PROFILE")
+	err := os.Unsetenv("OSC_ACCESS_KEY")
+	if err != nil {
+		t.Fatalf("Unsetenv: %v", err)
+	}
+	err = os.Unsetenv("OSC_SECRET_KEY")
+	if err != nil {
+		t.Fatalf("Unsetenv: %v", err)
+	}
+	err = os.Unsetenv("OSC_REGION")
+	if err != nil {
+		t.Fatalf("Unsetenv: %v", err)
+	}
+	err = os.Unsetenv("OSC_PROFILE")
+	if err != nil {
+		t.Fatalf("Unsetenv: %v", err)
+	}
 
 	t.Setenv("OUTSCALE_ACCESSKEYID", "deprecated-ak")
 	t.Setenv("OUTSCALE_SECRETKEYID", "deprecated-sk")
@@ -129,10 +141,10 @@ func TestAccessconfigDeprecatedEnv(t *testing.T) {
 		t.Fatalf("NewProfile: %v", err)
 	}
 	if p.AccessKey != "deprecated-ak" {
-		t.Fatalf("expected deprecated access key, got %q", p.AccessKey)
+		t.Fatalf("expected deprecated access key")
 	}
 	if p.SecretKey != "deprecated-sk" {
-		t.Fatalf("expected deprecated secret key, got %q", p.SecretKey)
+		t.Fatalf("expected deprecated secret key")
 	}
 	if p.Region != "deprecated-region" {
 		t.Fatalf("expected deprecated region, got %q", p.Region)

--- a/builder/common/access_config_test.go
+++ b/builder/common/access_config_test.go
@@ -1,0 +1,140 @@
+package common_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/outscale/osc-sdk-go/v3/pkg/profile"
+	"github.com/outscale/packer-plugin-outscale/builder/common"
+)
+
+func TestAccessconfigConfigPriority(t *testing.T) {
+	t.Setenv("OSC_ACCESS_KEY", "env-ak")
+	t.Setenv("OSC_SECRET_KEY", "env-sk")
+	t.Setenv("OSC_REGION", "env-region")
+	t.Setenv("OUTSCALE_ACCESSKEYID", "deprecated-ak")
+	t.Setenv("OUTSCALE_SECRETKEYID", "deprecated-sk")
+	t.Setenv("OUTSCALE_REGION", "deprecated-region")
+
+	c := &common.AccessConfig{
+		AccessKey: "config-ak",
+		SecretKey: "config-sk",
+		RawRegion: "config-region",
+	}
+
+	p, err := c.NewProfile()
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	if p.AccessKey != "config-ak" {
+		t.Fatalf("expected config access key, got %q", p.AccessKey)
+	}
+	if p.SecretKey != "config-sk" {
+		t.Fatalf("expected config secret key, got %q", p.SecretKey)
+	}
+	if p.Region != "config-region" {
+		t.Fatalf("expected config region, got %q", p.Region)
+	}
+}
+
+func TestAccessconfigProfilePriority(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	cf := profile.ConfigFile{
+		Path: configPath,
+		Profiles: map[string]profile.Profile{
+			"default": {
+				AccessKey: "default-ak",
+				SecretKey: "default-sk",
+			},
+			"test": {
+				AccessKey: "file-ak",
+				SecretKey: "file-sk",
+			},
+		},
+	}
+	if err := cf.Save(); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	t.Setenv("OSC_CONFIG_FILE", configPath)
+	t.Setenv("OSC_ACCESS_KEY", "env-ak")
+	t.Setenv("OSC_SECRET_KEY", "env-sk")
+	t.Setenv("OSC_REGION", "env-region")
+	t.Setenv("OUTSCALE_ACCESSKEYID", "deprecated-ak")
+	t.Setenv("OUTSCALE_SECRETKEYID", "deprecated-sk")
+	t.Setenv("OUTSCALE_REGION", "deprecated-region")
+
+	c := &common.AccessConfig{ProfileName: "test"}
+
+	p, err := c.NewProfile()
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	if p.AccessKey != "file-ak" {
+		t.Fatalf("expected file access key, got %q", p.AccessKey)
+	}
+	if p.SecretKey != "file-sk" {
+		t.Fatalf("expected file secret key, got %q", p.SecretKey)
+	}
+	if p.Region != "env-region" {
+		t.Fatalf("expected env region, got %q", p.Region)
+	}
+}
+
+func TestAccessconfigEnvPriority(t *testing.T) {
+	t.Setenv("OSC_ACCESS_KEY", "env-ak")
+	t.Setenv("OSC_SECRET_KEY", "env-sk")
+	t.Setenv("OSC_REGION", "env-region")
+	t.Setenv("OUTSCALE_ACCESSKEYID", "deprecated-ak")
+	t.Setenv("OUTSCALE_SECRETKEYID", "deprecated-sk")
+	t.Setenv("OUTSCALE_REGION", "deprecated-region")
+
+	c := &common.AccessConfig{}
+
+	p, err := c.NewProfile()
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	if p.AccessKey != "env-ak" {
+		t.Fatalf("expected env access key, got %q", p.AccessKey)
+	}
+	if p.SecretKey != "env-sk" {
+		t.Fatalf("expected env secret key, got %q", p.SecretKey)
+	}
+	if p.Region != "env-region" {
+		t.Fatalf("expected env region, got %q", p.Region)
+	}
+}
+
+func TestAccessconfigDeprecatedEnv(t *testing.T) {
+	// Unset env vars that would override deprecated env vars
+	t.Setenv("OSC_ACCESS_KEY", "")
+	t.Setenv("OSC_SECRET_KEY", "")
+	t.Setenv("OSC_REGION", "")
+	t.Setenv("OSC_PROFILE", "")
+	os.Unsetenv("OSC_ACCESS_KEY")
+	os.Unsetenv("OSC_SECRET_KEY")
+	os.Unsetenv("OSC_REGION")
+	os.Unsetenv("OSC_PROFILE")
+
+	t.Setenv("OUTSCALE_ACCESSKEYID", "deprecated-ak")
+	t.Setenv("OUTSCALE_SECRETKEYID", "deprecated-sk")
+	t.Setenv("OUTSCALE_REGION", "deprecated-region")
+
+	c := &common.AccessConfig{}
+
+	p, err := c.NewProfile()
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	if p.AccessKey != "deprecated-ak" {
+		t.Fatalf("expected deprecated access key, got %q", p.AccessKey)
+	}
+	if p.SecretKey != "deprecated-sk" {
+		t.Fatalf("expected deprecated secret key, got %q", p.SecretKey)
+	}
+	if p.Region != "deprecated-region" {
+		t.Fatalf("expected deprecated region, got %q", p.Region)
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -80,17 +80,28 @@ These look like:
 
 #### Environment variables
 
-You can provide your credentials via the `OUTSCALE_ACCESSKEYID` and
-`OUTSCALE_SECRETKEYID`, environment variables, representing your Outscale Access
-Key and Outscale Secret Key, respectively. The `OUTSCALE_REGION` and
-`OUTSCALE_OAPI_URL` environment variables are also used, if applicable:
+You can provide your credentials via the following environment variables:
+
+- `OSC_ACCESS_KEY`
+- `OSC_SECRET_KEY`
+- `OSC_REGION`
+- `OSC_ENDPOINT_API`
 
 Usage:
 
-    $ export OUTSCALE_ACCESSKEYID="XXX_ACCESS_KEY_XXX"
-    $ export OUTSCALE_SECRETKEYID="XXX_SECRET_KEY_XXX"
-    $ export OUTSCALE_REGION="eu-west-2"
+    $ export OSC_ACCESS_KEY="XXX_ACCESS_KEY_XXX"
+    $ export OSC_SECRET_KEY="XXX_SECRET_KEY_XXX"
+    $ export OSC_REGION="eu-west-2"
     $ packer build template.pkr.hcl
+
+Legacy `OUTSCALE_*` variables are still supported for compatibility, but they are deprecated and will be removed in the next major version.
+
+Deprecated variables:
+
+- `OUTSCALE_ACCESSKEYID` -> `OSC_ACCESS_KEY`
+- `OUTSCALE_SECRETKEYID` -> `OSC_SECRET_KEY`
+- `OUTSCALE_REGION` -> `OSC_REGION`
+- `OUTSCALE_OAPI_URL` -> `OSC_ENDPOINT_API`
 
 #### x509 Certificate Authentication
 
@@ -102,9 +113,14 @@ You can set this certificates either by environment variables or by the static c
 ##### Environment variables
 
 ```bash
-export OUTSCALE_X509CERT="the/path/to/your/x509cert"
-export OUTSCALE_X509KEY="the/path/to/your/x509key"
+export OSC_X509_CLIENT_CERT="the/path/to/your/x509cert"
+export OSC_X509_CLIENT_KEY="the/path/to/your/x509key"
 ```
+
+Legacy x509 environment variables are also deprecated:
+
+- `OUTSCALE_X509CERT` -> `OSC_X509_CLIENT_CERT`
+- `OUTSCALE_X509KEY` -> `OSC_X509_CLIENT_KEY`
 
 ##### Static Credentials
 


### PR DESCRIPTION
## Description

- Deprecates OUTSCALE_* prefixed environment variables
- Updates the Packer configuration loading order to be, by priority:
  Packer configuration > Profile (specified in configuration or in
  environment variable) > Environment variables > Deprecated environment variables
- Update documentation about environment variables deprecation

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [X] 🧹 Code cleanup or refactor
- [X] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [X] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [X] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [X] I have added tests or explained why they are not needed
* [X] I have updated relevant documentation (README, examples, etc.)
* [X] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [X] My commits include appropriate [Gitmoji](https://gitmoji.dev/)
